### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ phpunit.xml
 .php_cs.cache
 .php_cs
 composer.lock
+.php-cs-fixer.cache
+.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,10 +1,11 @@
 <?php
-        $finder = PhpCsFixer\Finder::create()
-        ->in('./src')
-        ->in('./tests');
 
-        return PhpCsFixer\Config::create()
-        ->setRules([
+$finder = PhpCsFixer\Finder::create()
+    ->in('./src')
+    ->in('./tests');
+
+return (new PhpCsFixer\Config)
+    ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
         'phpdoc_add_missing_param_annotation' => true,
@@ -14,5 +15,5 @@
         'phpdoc_order' => true,
         'phpdoc_align' => true,
         'ordered_imports' => true,
-        ])
-        ->setFinder($finder);
+    ])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1|^8.0",
+        "ext-soap": "*"
     },
     "autoload": {
         "psr-4": {
@@ -24,9 +25,9 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.4",
-        "phpstan/phpstan-shim": "^0.10.3",
-        "squizlabs/php_codesniffer": "^3.3",
-        "friendsofphp/php-cs-fixer": "^2.13"
+        "phpunit/phpunit": "^7.4|^8.0|^9.0",
+        "phpstan/phpstan": "^1.10",
+        "squizlabs/php_codesniffer": "^3.7",
+        "friendsofphp/php-cs-fixer": "^3.35"
     }
 }

--- a/src/VatApi/Exception/InvalidCodeValueException.php
+++ b/src/VatApi/Exception/InvalidCodeValueException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VatApi\Exception;
 
 class InvalidCodeValueException extends \InvalidArgumentException

--- a/src/VatApi/Exception/InvalidNipNumberException.php
+++ b/src/VatApi/Exception/InvalidNipNumberException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VatApi\Exception;
 
 class InvalidNipNumberException extends \InvalidArgumentException

--- a/src/VatApi/StatusDecoder.php
+++ b/src/VatApi/StatusDecoder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VatApi;
 
 use VatApi\Exception\InvalidCodeValueException;
@@ -10,18 +11,16 @@ class StatusDecoder
     public const STATUS_MAP = [
         'N' => TaxStatusInterface::TAXPAYER_NOT_ACTIVE,
         'C' => TaxStatusInterface::TAXPAYER_ACTIVE,
-        'Z' => TaxStatusInterface::TAXPAYER_FREE
+        'Z' => TaxStatusInterface::TAXPAYER_FREE,
     ];
 
     /**
-     * @param VatStatusResponse $response
-     * @return int
      * @throws InvalidNipNumberException
      * @throws InvalidCodeValueException
      */
     public static function decode(VatStatusResponse $response): int
     {
-        if ($response->getKod() === 'I') {
+        if ('I' === $response->getKod()) {
             throw new InvalidNipNumberException($response->getKomunikat());
         }
 

--- a/src/VatApi/TaxStatusInterface.php
+++ b/src/VatApi/TaxStatusInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VatApi;
 
 interface TaxStatusInterface

--- a/src/VatApi/Type/Response/VatStatusResponse.php
+++ b/src/VatApi/Type/Response/VatStatusResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VatApi\Type\Response;
 
 class VatStatusResponse
@@ -13,33 +14,21 @@ class VatStatusResponse
      */
     public $Komunikat;
 
-    /**
-     * @return string
-     */
     public function getKod(): string
     {
         return $this->Kod;
     }
 
-    /**
-     * @param string $kod
-     */
     public function setKod(string $kod): void
     {
         $this->Kod = $kod;
     }
 
-    /**
-     * @return string
-     */
     public function getKomunikat(): string
     {
         return $this->Komunikat;
     }
 
-    /**
-     * @param string $komunikat
-     */
     public function setKomunikat(string $komunikat): void
     {
         $this->Komunikat = $komunikat;

--- a/src/VatApi/VatApi.php
+++ b/src/VatApi/VatApi.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VatApi;
 
 use VatApi\Exception\InvalidCodeValueException;
@@ -13,9 +14,8 @@ class VatApi
 
     /**
      * VatApi constructor.
-     * @param \SoapClient $soapClient
      */
-    public function __construct(?\SoapClient $soapClient = null)
+    public function __construct(\SoapClient $soapClient = null)
     {
         $this->soapClient = $soapClient ?? new \SoapClient(
             VatApiConstantInterface::WSDL_ADDRESS,
@@ -24,15 +24,13 @@ class VatApi
     }
 
     /**
-     * @param string $nipNumber
-     * @return int
      * @throws InvalidNipNumberException
      * @throws InvalidCodeValueException
      */
     public function getNipStatus(string $nipNumber): int
     {
         $response = $this->soapClient->__soapCall(VatApiConstantInterface::CHECK_NIP_FUNCTION, [
-            VatApiConstantInterface::NIP_CHECK_PARAM => $nipNumber
+            VatApiConstantInterface::NIP_CHECK_PARAM => $nipNumber,
         ]);
 
         return StatusDecoder::decode($response);

--- a/src/VatApi/VatApiConstantInterface.php
+++ b/src/VatApi/VatApiConstantInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VatApi;
 
 use VatApi\Type\Response\VatStatusResponse;
@@ -15,7 +16,7 @@ interface VatApiConstantInterface
 
     public const DEFAULT_API_OPTIONS = [
         'classmap' => [
-            VatApiConstantInterface::VAT_RESPONSE => VatStatusResponse::class
-        ]
+            VatApiConstantInterface::VAT_RESPONSE => VatStatusResponse::class,
+        ],
     ];
 }

--- a/tests/Integration/VatApiTest.php
+++ b/tests/Integration/VatApiTest.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace VatApi\Integration;
 
 use PHPUnit\Framework\TestCase;
+use VatApi\Exception\InvalidNipNumberException;
 use VatApi\TaxStatusInterface;
 use VatApi\VatApi;
 
@@ -15,11 +17,10 @@ class VatApiTest extends TestCase
         $this->assertEquals(TaxStatusInterface::TAXPAYER_ACTIVE, $response);
     }
 
-    /**
-     * @expectedException VatApi\Exception\InvalidNipNumberException
-     */
-    public function testGetNipStatuwWithInvalidNip()
+    public function testGetNipStatusWithInvalidNip()
     {
+        $this->expectException(InvalidNipNumberException::class);
+
         $api = new VatApi();
         $response = $api->getNipStatus('1231231221');
 

--- a/tests/Unit/StatusDecoderTest.php
+++ b/tests/Unit/StatusDecoderTest.php
@@ -1,11 +1,13 @@
 <?php
+
 namespace VatApi;
 
 use PHPUnit\Framework\TestCase;
+use VatApi\Exception\InvalidCodeValueException;
+use VatApi\Exception\InvalidNipNumberException;
 
 class StatusDecoderTest extends TestCase
 {
-
     public function testDecodeWithWalidResponse()
     {
         $response = new Type\Response\VatStatusResponse();
@@ -15,11 +17,10 @@ class StatusDecoderTest extends TestCase
         $this->assertEquals(TaxStatusInterface::TAXPAYER_ACTIVE, $status);
     }
 
-    /**
-     * @expectedException VatApi\Exception\InvalidNipNumberException
-     */
     public function testDecodeWithInvalidNumber()
     {
+        $this->expectException(InvalidNipNumberException::class);
+
         $response = new Type\Response\VatStatusResponse();
         $response->setKod('I');
         $response->setKomunikat('Niepoprawny Numer Identyfikacji Podatkowej');
@@ -27,11 +28,10 @@ class StatusDecoderTest extends TestCase
         $status = StatusDecoder::decode($response);
     }
 
-    /**
-     * @expectedException VatApi\Exception\InvalidCodeValueException
-     */
     public function testDecodeWithInvalidCode()
     {
+        $this->expectException(InvalidCodeValueException::class);
+
         $response = new Type\Response\VatStatusResponse();
         $response->setKod('X');
 

--- a/tests/Unit/VatApiTest.php
+++ b/tests/Unit/VatApiTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace VatApi;
 
 use PHPUnit\Framework\TestCase;
@@ -16,7 +17,7 @@ class VatApiTest extends TestCase
             ->expects($this->once())
             ->method('__soapCall')
             ->with(VatApiConstantInterface::CHECK_NIP_FUNCTION, [
-                VatApiConstantInterface::NIP_CHECK_PARAM => '1231231223'
+                VatApiConstantInterface::NIP_CHECK_PARAM => '1231231223',
             ])
             ->willReturn($response);
 


### PR DESCRIPTION
## About
- Updates dependencies to work on PHP 8
- Fixes tests to avoid deprecation warnings
- Applies new styling from PHP CS Fixer

Test on: PHP 8.2.11

![Screenshot_5](https://github.com/johnzuk/VatApi/assets/37669560/fc058e82-18c6-45c9-9c2e-c4af0bd2c980)